### PR TITLE
Fix for regeneration of preflights on browser refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ function _preprocess(content: string, filename: string) {
     true,
     FILES.length === 0 || FILES.indexOf(filename) === 0,
     true,
-    !DEV
+    DEV
   );
 
   const styleSheet = (OPTIONS.globalPreflight && !OPTIONS.bundle


### PR DESCRIPTION
I think that it might was a typo. Code seems to mean if `DEV = true`    
However it was that to `DEV = false`, it does work for me with esbuild and snowpack.

@voorjaar could we do a test tag for this pr on the NPM package so other people could test with their bundler, before it breaks any other configuration I might not have with my bundlers??