### PR TITLE
[enhancement] adds logging to preprocess

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -165,7 +164,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -176,7 +174,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -184,8 +181,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colors": {
       "version": "1.4.0",
@@ -226,8 +222,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "estree-walker": {
       "version": "1.0.1",
@@ -280,8 +275,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "inflight": {
       "version": "1.0.6",
@@ -577,7 +571,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "homepage": "https://github.com/voorjaar/svelte-windicss-preprocess",
   "dependencies": {
+    "chalk": "^2.4.2",
     "magic-string": "^0.25.7",
     "windicss": "^2.1.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,6 +73,7 @@ const main = {
   ],
   external: [
     "magic-string",
+    "chalk",
     "windicss/lib",
     "windicss/utils/parser",
     "windicss/utils/style",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import MagicString from "magic-string";
+import chalk from "chalk";
 import { Processor } from "windicss/lib";
 import { CSSParser } from "windicss/utils/parser";
 import { loadConfig, writeFileSync, combineStyleList, globalStyleSheet } from "./utils";
@@ -17,6 +18,8 @@ let FILES: (string | undefined)[] = [];
 let BUNDLES: { [key: string]: StyleSheet } = {};
 
 let OPTIONS: {
+  debug?: boolean;
+  silent?: boolean;
   config?: string;
   compile?: boolean;
   prefix?: string;
@@ -149,16 +152,14 @@ function _preprocess(content: string, filename: string) {
       if (OPTIONS.compile) {
         code.prependLeft(
           classStart,
-          `class="${compilation(classes.join(" "))}${
-            expressions.length > 0 ? " " + expressions.join(" ") : ""
+          `class="${compilation(classes.join(" "))}${expressions.length > 0 ? " " + expressions.join(" ") : ""
           }"`
         );
       } else {
         interpretation(classes.join(" "));
         code.prependLeft(
           classStart,
-          `class="${classes.join(" ")}${
-            expressions.length > 0 ? " " + expressions.join(" ") : ""
+          `class="${classes.join(" ")}${expressions.length > 0 ? " " + expressions.join(" ") : ""
           }"`
         );
       }
@@ -210,7 +211,40 @@ function _optimize(types: string, typeNodes: { [key: string]: string }) {
   writeFileSync(BUNDLEFILE, parser.parse().build(true));
 }
 
+function _blueBold(text: string) {
+  return chalk.hex("#0ea5e9").bold(text);
+}
+function _blackBold(text: string) {
+  return chalk.hex("#000").bold(text);
+}
+function _yellowBold(text: string) {
+  return chalk.hex("#FFB11B").bold(text);
+}
+function _redBold(text: string) {
+  return chalk.hex("#FF4000").bold(text);
+}
+function _green(text: string) {
+  return chalk.hex("#00D17A")(text);
+}
+function _gray(text: string) {
+  return chalk.hex("#717272")(text);
+}
 export function preprocess(options: typeof OPTIONS = {}) {
+  if (options?.silent === false) {
+    process.stdout.write(`${_blueBold("│")}\n`)
+    process.stdout.write(`${_blueBold("│")} ${_blueBold("svelte-windicss-preprocess")} - v${require("./package.json").version}\n`)
+    process.stdout.write(`${_blueBold("│")} ${process.env.NODE_ENV == undefined ? _redBold("NODE_ENV is undefined") : ""}\n`)
+    process.stdout.write(`${_blueBold("│")} ${_blackBold("-")} windicss running mode: ${process.env.NODE_ENV === 'development' ? _yellowBold("dev") : _green("prod")}\n`)
+    process.stdout.write(`${_blueBold("│")} ${_blackBold("-")} advanced debug logs: ${options?.debug === true ? _yellowBold("on") : _green("off")}\n`)
+    if (options?.debug === true) {
+      process.stdout.write(`${_blueBold("│")}    ${_blackBold("•")} compilation mode: ${options?.compile == true ? _gray("enabled") : _gray("disabled")}\n`)
+      process.stdout.write(`${_blueBold("│")}    ${_blackBold("•")} class prefix: ${options?.prefix ? _gray(options.prefix) : _yellowBold("not set")}\n`)
+      process.stdout.write(`${_blueBold("│")}    ${_blackBold("•")} global preflights: ${options?.globalPreflight == true ? _gray("enabled") : _gray("disabled")}\n`)
+      process.stdout.write(`${_blueBold("│")}    ${_blackBold("•")} global utilities: ${options?.globalUtility == true ? _gray("enabled") : _gray("disabled")}\n`)
+    }
+    process.stdout.write(`${_blueBold("│")}\n`)
+    process.stdout.write(`${_blueBold("└──────────")}\n`)
+  }
   OPTIONS = { ...OPTIONS, ...options }; // change global settings here;
   PROCESSOR = new Processor(loadConfig(OPTIONS.config));
   VARIANTS = [


### PR DESCRIPTION
Firstly, I would like to give a big thank you, for inviting me :)
I would have some questions so feel free to give me your opinion:

a) should I open new branches in the future in this repo, or take the way over my own forked repo?
b) would you be more than happy to keep discussing stuff here?

Now to the main PR. I added some logging, so debugging is easier, and people can understand the preprocessor a little bit more.
For that I have added two new config parameters to the preprocessor 
  - `silent` which adds or removes logging completely 
  - `debug` which extends logging with more advanced config parameters.

It is a first start, and logging can get improved with more stuff over time.

I have structured the code in some color helper functions and added `chalk` as a dependency which is the most used easy logging solution, so color changing of text and adding new colors is quite easy. 

**If you wish to implement it natively with ANSI escape codes, I can change that, however it is easier to maintain with helper function. Also, if you would like to reduce the amount of color functions, I can collapse them into one, just let me know what code style you would prefer for this project. I am very happy to adapt to it.** 

I am marking this as a DRAFT PR, so we can get the code style and colors dialed in.

`silent: false, debug: false`
![DevNoDebugCorrect](https://user-images.githubusercontent.com/45965090/108591925-749be200-736b-11eb-97c3-60a384c7389f.png)
`silent: false, debug: false`
![ProdNoDebugCorrect](https://user-images.githubusercontent.com/45965090/108591924-74034b80-736b-11eb-8ce3-3327899245ae.png)
`silent: false, debug: true`
![DevDebugCorrect](https://user-images.githubusercontent.com/45965090/108591923-736ab500-736b-11eb-9c00-1b9d949dd2e7.png)
`silent: false, debug: true`
![ProdDebugCorrect](https://user-images.githubusercontent.com/45965090/108591927-749be200-736b-11eb-8768-47188b69e460.png)
![MissingEnv](https://user-images.githubusercontent.com/45965090/108591926-749be200-736b-11eb-8af6-8442e03cdc84.png)
