### PR TITLE
[patch-#11] add workaround for template literals

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,14 @@ function addVariant(classNames: string, variant: string) {
   return [...utilities, ...groups].map((i) => `${variant}:${i}`).join(" ");
 }
 
+function _convertTemplateSyntax(content: string): string {
+  let parsedContent = content;
+  parsedContent = parsedContent.replace(/\{`/g, '" ');
+  parsedContent = parsedContent.replace(/`\}/g, ' "');
+  parsedContent = parsedContent.replace(/\$/g, " ");
+  return parsedContent
+}
+
 function _preprocess(content: string, filename: string) {
   content = content.replace(/<!--[\s\S]*?-->/g, '');
   let style = content.match(REGEXP.matchStyle)?.[0];
@@ -93,7 +101,7 @@ function _preprocess(content: string, filename: string) {
   }
 
   const code = new MagicString(content);
-  const parser = new HTMLParser(content);
+  const parser = new HTMLParser(_convertTemplateSyntax(content));
   parser.parse().forEach((tag) => {
     let classes: string[] = [];
     let conditionClasses: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,11 @@ function addVariant(classNames: string, variant: string) {
 }
 
 function _convertTemplateSyntax(content: string): string {
+  // converts content temporarily from special svelte syntax to more generic syntax for parsing ...
+  // from : <div class={`green ${myClass ? 'red' : 'green'}`}>Should be red!</div>
+  // to : <div class="green {myClass ? 'red' : 'green'}">Should be red!</div>
   let parsedContent = content;
+  // needs make sure length and position are the same, so replacing with spaces
   parsedContent = parsedContent.replace(/\{`/g, '" ');
   parsedContent = parsedContent.replace(/`\}/g, ' "');
   parsedContent = parsedContent.replace(/\$/g, " ");
@@ -101,6 +105,8 @@ function _preprocess(content: string, filename: string) {
   }
 
   const code = new MagicString(content);
+  // uses new convertion, can be reverted quickly if this breaks to much bu changing to
+  // old : const parser = new HTMLParser(content);
   const parser = new HTMLParser(_convertTemplateSyntax(content));
   parser.parse().forEach((tag) => {
     let classes: string[] = [];


### PR DESCRIPTION
This is the first `"hacky"` implementation of a workaround for template literals, will clean up tomorrow and improve before we can test and merge