### PR TITLE
chore: move windicss package to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 npm install svelte-windicss-preprocess --save-dev
 ```
 
+If you haven't installed `windicss`, please install it first.
+
+```sh
+npm install windicss --save-dev
+```
+
 ## Configuration
 
 ### Svelte
@@ -214,20 +220,20 @@ You can write any [tailwindcss](https://github.com/tailwindlabs/tailwindcss) cla
 </script>
 
 <div
-  class="py-8 px-8 max-w-sm mx-auto bg-white rounded-xl shadow-md space-y-2 sm:py-4 sm:flex sm:items-center sm:space-y-0 sm:space-x-6"
+  class="max-w-sm px-8 py-8 mx-auto space-y-2 bg-white shadow-md rounded-xl sm:py-4 sm:flex sm:items-center sm:space-y-0 sm:space-x-6"
 >
   <img
-    class="block mx-auto h-24 rounded-full sm:mx-0 sm:flex-shrink-0"
+    class="block h-24 mx-auto rounded-full sm:mx-0 sm:flex-shrink-0"
     src="/img/erin-lindford.jpg"
     alt="Woman's Face"
   />
-  <div class="text-center space-y-2 sm:text-left">
+  <div class="space-y-2 text-center sm:text-left">
     <div class="space-y-0.5">
-      <p class="text-lg text-black font-semibold">Erin Lindford</p>
-      <p class="text-gray-500 font-medium">Product Engineer</p>
+      <p class="text-lg font-semibold text-black">Erin Lindford</p>
+      <p class="font-medium text-gray-500">Product Engineer</p>
     </div>
     <button
-      class="px-4 py-1 text-sm text-purple-600 font-semibold rounded-full border border-purple-200 hover:text-white hover:bg-purple-600 hover:border-transparent focus:outline-none focus:ring-2 focus:ring-purple-600 focus:ring-offset-2"
+      class="px-4 py-1 text-sm font-semibold text-purple-600 border border-purple-200 rounded-full hover:text-white hover:bg-purple-600 hover:border-transparent focus:outline-none focus:ring-2 focus:ring-purple-600 focus:ring-offset-2"
     >
       Message
     </button>

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "homepage": "https://github.com/voorjaar/svelte-windicss-preprocess",
   "dependencies": {
     "chalk": "^2.4.2",
-    "magic-string": "^0.25.7",
-    "windicss": "2.1.14"
+    "magic-string": "^0.25.7"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^11.1.1",
@@ -55,5 +54,8 @@
     "ts-node": "^9.1.1",
     "tslib": "^2.1.0",
     "typescript": "^4.1.3"
+  },
+  "peerDependencies": {
+    "windicss": "2.1.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^9.1.1",
     "tslib": "^2.1.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "windicss": "^2.1.19"
   },
   "peerDependencies": {
     "windicss": "2.1.19"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ devDependencies:
   ts-node: 9.1.1_typescript@4.1.5
   tslib: 2.1.0
   typescript: 4.1.5
+  windicss: 2.1.19
 lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.12.13:
@@ -1213,6 +1214,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  /windicss/2.1.19:
+    dev: true
+    engines:
+      node: '>= 12'
+    hasBin: true
+    resolution:
+      integrity: sha512-jqHQ6tEWt/nxN/KLvxYyqO6K0JV3nlwC5D60Hrry02G4D3h0gx/dN/3FaqC0n5EqOKCcIrDasrmclquKiJA4JQ==
   /wrappy/1.0.2:
     dev: true
     resolution:
@@ -1252,3 +1260,4 @@ specifiers:
   ts-node: ^9.1.1
   tslib: ^2.1.0
   typescript: ^4.1.3
+  windicss: ^2.1.19

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,6 @@
 dependencies:
   chalk: 2.4.2
   magic-string: 0.25.7
-  windicss: 2.1.14
 devDependencies:
   '@rollup/plugin-node-resolve': 11.2.0_rollup@2.39.0
   '@rollup/plugin-replace': 2.3.4_rollup@2.39.0
@@ -1214,13 +1213,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  /windicss/2.1.14:
-    dev: false
-    engines:
-      node: '>= 12'
-    hasBin: true
-    resolution:
-      integrity: sha512-qxsiUxH81yYI9StGSi/A9RVcbtNdMBgbxmBnt25p8pRbk+NSeRJTATA9/NSJOmxuvscc1NVq8BjaFCzILpKrkg==
   /wrappy/1.0.2:
     dev: true
     resolution:
@@ -1260,4 +1252,3 @@ specifiers:
   ts-node: ^9.1.1
   tslib: ^2.1.0
   typescript: ^4.1.3
-  windicss: 2.1.14


### PR DESCRIPTION
`peerDependencies` give users the flexibility to update the version of `windicss` to the latest version without waiting for the update of `svelte-windicss-preprocess` library.

Ref:

- https://nodejs.org/es/blog/npm/peer-dependencies/
- https://flaviocopes.com/npm-peer-dependencies/
