### PR TITLE
Remove extra space between text and expression

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,13 +133,13 @@ function _preprocess(content: string, filename: string) {
       if (OPTIONS.compile) {
         code.prependLeft(
           classStart,
-          `class="${compilation(classes.join(' '))}${expressions.length > 0 ? ' ' + expressions.join(' ') : ''}"`
+          `class="${compilation(classes.join(' '))}${expressions.length > 0 ? expressions.join(' ') : ''}"`
         );
       } else {
         interpretation(classes.join(' '));
         code.prependLeft(
           classStart,
-          `class="${classes.join(' ')}${expressions.length > 0 ? ' ' + expressions.join(' ') : ''}"`
+          `class="${classes.join(' ')}${expressions.length > 0 ? expressions.join(' ') : ''}"`
         );
       }
     }


### PR DESCRIPTION
As discussed in [the issue](https://github.com/windicss/svelte-windicss-preprocess/issues/44), this PR fix the introduction of an extra space in classes names.

```html
<div class={`resizer resizer--${axe}`}>...</div>
became
 <div class="resizer resizer-- {axe}">...</div>
```
With this PR, the extra space is no more
```html
<div class={`resizer resizer--${axe}`}>...</div>
became
 <div class="resizer resizer--{axe}">...</div>
```