### PR TITLE
chore(docs): support typescript for Svelte config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ npm install svelte-windicss-preprocess --save-dev
 
 Add `svelte-windicss-preprocess` to your `rollup.config.js`.
 
+**Note:** `typescript` is **optional**. Include `sveltePreprocess.typescript()` if you are using typescript in your Svelte component.
 ```js
 // rollup.config.js
 import sveltePreprocess from "svelte-preprocess";
@@ -50,7 +51,7 @@ export default {
     svelte({
       // svelte-windicss-preprocess
       preprocess: [
-        sveltePreprocess.typescript(), // to support typscript (optional)
+        sveltePreprocess.typescript(), // to support typescript (optional)
         require('svelte-windicss-preprocess').preprocess({
           config: 'tailwind.config.js', // tailwind config file path (optional)
           compile: true, // false: interpretation mode; true: compilation mode

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install svelte-windicss-preprocess --save-dev
 
 Add `svelte-windicss-preprocess` to your `rollup.config.js`.
 
-**Note:** `typescript` is **optional**. Include `sveltePreprocess.typescript()` if you are using typescript in your Svelte component.
+> Typescript is **optional**. Include `sveltePreprocess.typescript()` into `preprocess` if you are using typescript in your Svelte component.
 ```js
 // rollup.config.js
 import sveltePreprocess from "svelte-preprocess";

--- a/README.md
+++ b/README.md
@@ -42,19 +42,23 @@ Add `svelte-windicss-preprocess` to your `rollup.config.js`.
 
 ```js
 // rollup.config.js
+import sveltePreprocess from "svelte-preprocess";
 // ...
 export default {
   // ...
   plugins: [
     svelte({
       // svelte-windicss-preprocess
-      preprocess: require('svelte-windicss-preprocess').preprocess({
-        config: 'tailwind.config.js', // tailwind config file path (optional)
-        compile: true, // false: interpretation mode; true: compilation mode
-        prefix: 'windi-', // set compilation mode style prefix
-        globalPreflight: true, // set preflight style is global or scoped
-        globalUtility: true, // set utility style is global or scoped
-      }),
+      preprocess: [
+        sveltePreprocess.typescript(), // to support typscript (optional)
+        require('svelte-windicss-preprocess').preprocess({
+          config: 'tailwind.config.js', // tailwind config file path (optional)
+          compile: true, // false: interpretation mode; true: compilation mode
+          prefix: 'windi-', // set compilation mode style prefix
+          globalPreflight: true, // set preflight style is global or scoped
+          globalUtility: true, // set utility style is global or scoped
+        })
+      ],
       // ...
     }),
   ],


### PR DESCRIPTION
I have spent hours debugging typescript error, on how to use svelte-preprocess with windicss. I didn't realize there is a typescript config in the **Sveltekit** section.

I added a typescript example for the **Svelte** section, I wish nobody will make the same mistake as I am