### PR TITLE
Make preprocess only extract from classes from ternary operators

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,9 @@ function _preprocess(content: string, filename: string) {
       if (FINAL_TEXT_MATCHES) {
         // console.log(FINAL_TEXT_MATCHES);
         let extractedClasses = FINAL_TEXT_MATCHES[3];
-        let INLINE_EXPRESSION = FINAL_TEXT_MATCHES[3].toString().match(/([\{].*?[\}])/gi);
+
+        // Find ternary operators and extract the classes
+        let INLINE_EXPRESSION = FINAL_TEXT_MATCHES[3].toString().match(/([\{].*[\?].*[\:].*[\}])/gi);
         if (INLINE_EXPRESSION) {
           // console.log(INLINE_EXPRESSION);
           extractedClasses = FINAL_TEXT_MATCHES[3].replace(/('|:|\}|[\{].*?\?)/gi, '');

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,12 +189,14 @@ function _preprocess(content: string, filename: string) {
         // console.log(FINAL_TEXT_MATCHES);
         let extractedClasses = FINAL_TEXT_MATCHES[3];
 
-        // Find ternary operators and extract the classes
-        let INLINE_EXPRESSION = FINAL_TEXT_MATCHES[3].toString().match(/([\{].*[\?].*[\:].*[\}])/gi);
+        // Match isolated inline expressions
+        let INLINE_EXPRESSION = FINAL_TEXT_MATCHES[3].toString().match(/("|'|\s)[\{].*?[\}]/gi);
+
+        // Extract classes from inline expressions
         if (INLINE_EXPRESSION) {
-          // console.log(INLINE_EXPRESSION);
-          extractedClasses = FINAL_TEXT_MATCHES[3].replace(/('|:|\}|[\{].*?\?)/gi, '');
+          extractedClasses = FINAL_TEXT_MATCHES[3].replace(/'|\?|:|{(?=[^}]+?\?).+?\?|(?<=:[^{]+?)}/gi, '');
         }
+
         if (OPTIONS.compile) {
           const COMPILED_CLASSES = PROCESSOR.compile(extractedClasses, OPTIONS.prefix, false);
           IGNORED_CLASSES = [...IGNORED_CLASSES, ...COMPILED_CLASSES.ignored];


### PR DESCRIPTION
Currently `<code class="language-{params}">{prism}</code>` gets extracted as `language-{params` which is not valid css syntax. With this PR only ternary operators get extracted from the string and those like in the example above stay untouched.