### PR TITLE
fix issue #259

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,6 +80,8 @@ export class Magician {
 
   setInject(): this {
     let tmpContent = this.content
+    tmpContent = tmpContent.replace('windi:inject', '')
+
     const styleMatch = tmpContent.match(/(?<openTag><style[^>]*?>)(?<content>[\s\S]*?)(?<closeTag><\/style>)/gi)
 
     if (styleMatch) {


### PR DESCRIPTION
Fixes #259 -  address double insertion of `windi:inject` when working with svelte component library using windicss.