### PR TITLE
Fix: now working with Node 14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "svelte-windicss-preprocess",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "license": "MIT",
       "dependencies": {
         "@iconify/json": "1.1.432",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,15 +99,15 @@ export class Magician {
     if (CLASS_MATCHES.length < 1) return this
     for (const match of CLASS_MATCHES) {
       const cleanMatch = match.groups?.classes
-        .replaceAll(/windi[`].+?[`]/gi, ' ') // windi`XYZ`
-        .replaceAll(/(?<![-])[$](?=[{])/gi, ' ') // if leading char is not -, and next char is {, then remove $
-        .replaceAll(/(?<=([{][\w\s]+[^{]*?))['"]/gi, ' ') // remove quotes in curly braces
-        .replaceAll(/(?<=([{][\w\s]+[^{]*?)\s)[:]/gi, ' ') // remove : in curly braces
-        .replaceAll(/([{][\w\s]+[^{]*?[?])/gi, ' ') // remove ? and condition in curly braces
-        .replaceAll(/[{}]/gi, ' ') // remove curly braces
-        .replaceAll(/\n/gi, ' ') // remove newline
-        .replaceAll(/ {2,}/gi, ' ') // remove multiple spaces
-        .replaceAll(/["'`]/gi, '') // remove quotes
+        .replace(/windi[`].+?[`]/gi, ' ') // windi`XYZ`
+        .replace(/(?<![-])[$](?=[{])/gi, ' ') // if leading char is not -, and next char is {, then remove $
+        .replace(/(?<=([{][\w\s]+[^{]*?))['"]/gi, ' ') // remove quotes in curly braces
+        .replace(/(?<=([{][\w\s]+[^{]*?)\s)[:]/gi, ' ') // remove : in curly braces
+        .replace(/([{][\w\s]+[^{]*?[?])/gi, ' ') // remove ? and condition in curly braces
+        .replace(/[{}]/gi, ' ') // remove curly braces
+        .replace(/\n/gi, ' ') // remove newline
+        .replace(/ {2,}/gi, ' ') // remove multiple spaces
+        .replace(/["'`]/gi, '') // remove quotes
 
       this.classes = this.classes.concat(
         (cleanMatch || '').split(' ').filter(c => {
@@ -126,15 +126,15 @@ export class Magician {
     if (CLASS_MATCHES.length < 1) return this
     for (const match of CLASS_MATCHES) {
       const cleanMatch = match.groups?.classes
-        .replaceAll(/windi[`].+?[`]/gi, ' ') // windi`XYZ`
-        .replaceAll(/(?<![-])[$](?=[{])/gi, ' ') // if leading char is not -, and next char is {, then remove $
-        .replaceAll(/(?<=([{][\w\s]+[^{]*?))['"]/gi, ' ') // remove quotes in curly braces
-        .replaceAll(/(?<=([{][\w\s]+[^{]*?)\s)[:]/gi, ' ') // remove : in curly braces
-        .replaceAll(/([{][\w\s]+[^{]*?[?])/gi, ' ') // remove ? and condition in curly braces
-        .replaceAll(/[{}]/gi, ' ') // remove curly braces
-        .replaceAll(/\n/gi, ' ') // remove newline
-        .replaceAll(/ {2,}/gi, ' ') // remove multiple spaces
-        .replaceAll(/["'`]/gi, '') // remove quotes
+        .replace(/windi[`].+?[`]/gi, ' ') // windi`XYZ`
+        .replace(/(?<![-])[$](?=[{])/gi, ' ') // if leading char is not -, and next char is {, then remove $
+        .replace(/(?<=([{][\w\s]+[^{]*?))['"]/gi, ' ') // remove quotes in curly braces
+        .replace(/(?<=([{][\w\s]+[^{]*?)\s)[:]/gi, ' ') // remove : in curly braces
+        .replace(/([{][\w\s]+[^{]*?[?])/gi, ' ') // remove ? and condition in curly braces
+        .replace(/[{}]/gi, ' ') // remove curly braces
+        .replace(/\n/gi, ' ') // remove newline
+        .replace(/ {2,}/gi, ' ') // remove multiple spaces
+        .replace(/["'`]/gi, '') // remove quotes
 
       this.classes = this.classes.concat(
         (cleanMatch || '').split(' ').filter(c => {


### PR DESCRIPTION
Fix the `TypeError: _a.classes.replaceAll is not a function` error when build a sveltejs-sveltekit project with Node <16 version, like node 14.

Closes: #400 